### PR TITLE
Use PROM2JSON to get metrics instead of rolling our own

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,8 @@ go 1.15
 require (
 	github.com/jaegertracing/jaeger-otelcol/test/tools/tracegen v0.0.0-20201218111612-2f0546350989
 	github.com/observatorium/opentelemetry-collector-builder v0.2.0
+	github.com/prometheus/client_model v0.2.0
+	github.com/prometheus/prom2json v1.3.0
 	github.com/sirupsen/logrus v1.7.0
 	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -202,6 +202,7 @@ github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -313,6 +314,8 @@ github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+Gx
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/procfs v0.2.0 h1:wH4vA7pcjKuZzjF7lM8awk4fnuJO6idemZXoKnULUx4=
 github.com/prometheus/procfs v0.2.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
+github.com/prometheus/prom2json v1.3.0 h1:BlqrtbT9lLH3ZsOVhXPsHzFrApCTKRifB7gjJuypu6Y=
+github.com/prometheus/prom2json v1.3.0/go.mod h1:rMN7m0ApCowcoDlypBHlkNbp5eJQf/+1isKykIP5ZnM=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=

--- a/test/e2e/agent/agent_sanity_test.go
+++ b/test/e2e/agent/agent_sanity_test.go
@@ -4,13 +4,15 @@ package e2e
 
 import (
 	"fmt"
-	"github.com/jaegertracing/jaeger-otelcol/test/e2e"
-	"github.com/jaegertracing/jaeger-otelcol/test/tools/tracegen"
+
 	"io/ioutil"
 	"os"
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/jaegertracing/jaeger-otelcol/test/e2e"
+	"github.com/jaegertracing/jaeger-otelcol/test/tools/tracegen"
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
@@ -28,7 +30,7 @@ func (suite *AgentSanityTestSuite) SetupSuite() {
 }
 
 func (suite *AgentSanityTestSuite) TearDownSuite() {
-	logrus.Infof("In teardown wuite")
+	logrus.Infof("In teardown suite")
 }
 
 func TestAgentSanityTestSuite(t *testing.T) {
@@ -70,8 +72,8 @@ func (suite *AgentSanityTestSuite) TestAgentSanity() {
 
 	// Check the metrics to verify that the agent received and then sent the number of spans expected
 	metricsEndpoint := "http://localhost:" + metricsPort + "/metrics"
-	receivedSpansMetric := e2e.GetMetric(t, metricsEndpoint, "otelcol_receiver_accepted_spans")
-	sentSpansMetric := e2e.GetMetric(t, metricsEndpoint, "otelcol_exporter_sent_spans")
-	require.Equal(t, strconv.Itoa(expectedSpanCount), receivedSpansMetric.Value)
-	require.Equal(t, strconv.Itoa(expectedSpanCount), sentSpansMetric.Value)
+	receivedSpansCounter := e2e.GetPrometheusCounter(t, metricsEndpoint, "otelcol_receiver_accepted_spans")
+	sentSpansCounter := e2e.GetPrometheusCounter(t, metricsEndpoint, "otelcol_exporter_sent_spans")
+	require.Equal(t, expectedSpanCount, int(receivedSpansCounter))
+	require.Equal(t, expectedSpanCount, int(sentSpansCounter))
 }

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -1,15 +1,16 @@
 package e2e
 
 import (
+	"crypto/tls"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
-	"strings"
 	"testing"
-	"time"
 
+	pcm "github.com/prometheus/client_model/go"
+	"github.com/prometheus/prom2json"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
@@ -17,13 +18,6 @@ import (
 var (
 	logrusLevel = getStringEnv("LOGRUS_LEVEL", "info")
 )
-
-// Metric can contain the value of a prometheus metric
-type Metric struct {
-	Key      string
-	JSONPart string
-	Value    string
-}
 
 func getStringEnv(key, defaultValue string) string {
 	if value, ok := os.LookupEnv(key); ok {
@@ -46,54 +40,39 @@ func StartCollector(t *testing.T, executable, configFileName string, loggerOutpu
 	return cmd
 }
 
-// GetMetric returns the value of the named metric
-func GetMetric(t *testing.T, metricsEndpoint string, metricKey string) Metric {
-	for _, m := range GetMetrics(t, metricsEndpoint) {
-		if m.Key == strings.TrimSpace(metricKey) {
-			return m
-		}
-	}
-
-	logrus.Warnf("Could not find metric %s at endpoint %s", metricKey, metricsEndpoint)
-	emptyMetric := Metric{}
-	return emptyMetric
+// GetPrometheusCounter returns the counter named from the specified endpoint
+func GetPrometheusCounter(t *testing.T, metricsEndpoint, metricName string) float64 {
+	counter := GetPrometheusMetric(t, metricsEndpoint, metricName)
+	return *counter.Metric[0].Counter.Value
 }
 
-// GetMetrics returns all metrics from the endpoint
-func GetMetrics(t *testing.T, metricsEndpoint string) []Metric {
-	httpClient := http.Client{Timeout: 5 * time.Second}
-
-	request, err := http.NewRequest(http.MethodGet, metricsEndpoint, nil)
-	require.NoError(t, err)
-	response, err := httpClient.Do(request)
-	require.NoError(t, err)
-
-	body, err := ioutil.ReadAll(response.Body)
-	require.NoError(t, err)
-
-	lines := strings.Split(string(body), "\n")
-	metrics := []Metric{}
-	for _, line := range lines {
-		if !strings.HasPrefix(line, "#") && strings.TrimSpace(line) != "" {
-			openBracket := strings.Index(line, "{")
-			closeBracket := strings.Index(line, "}") + 1
-			key := line[:openBracket]
-			jsonPart := line[openBracket:closeBracket]
-			value := line[closeBracket:]
-
-			metric := Metric{
-				Key:      key,
-				JSONPart: jsonPart,
-				Value:    strings.TrimSpace(value),
-			}
-			metrics = append(metrics, metric)
-		}
-	}
-
-	return metrics
+// GetPrometheusMetric returns the metric named from the specified endpoint
+func GetPrometheusMetric(t *testing.T, metricsEndpoint, metricName string) pcm.MetricFamily {
+	allMetrics := GetPrometheusMetrics(t, metricsEndpoint)
+	return allMetrics[metricName]
 }
 
-// SetLogrusLevel can be used to set the logging level
+// GetPrometheusMetrics returns all metrics from the specified endpoint
+func GetPrometheusMetrics(t *testing.T, metricsEndpoint string) map[string]pcm.MetricFamily {
+	// This code is mostly copied from https://github.com/prometheus/prom2json except it
+	// returns MetricFamily objects as that is more useful than JSON for tests.
+	mfChan := make(chan *pcm.MetricFamily, 1024)
+	tlsConfig := &tls.Config{InsecureSkipVerify: true}
+	transport := &http.Transport{
+		TLSClientConfig: tlsConfig,
+	}
+
+	err := prom2json.FetchMetricFamilies(metricsEndpoint, mfChan, transport)
+	require.NoError(t, err)
+	result := map[string]pcm.MetricFamily{}
+	for mf := range mfChan {
+		result[*mf.Name] = *mf
+	}
+
+	return result
+}
+
+// SetLogrusLevel sets the logging level
 func SetLogrusLevel(t *testing.T) {
 	ll, err := logrus.ParseLevel(logrusLevel)
 	require.NoError(t, err)

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -1,7 +1,6 @@
 package e2e
 
 import (
-	"crypto/tls"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -57,12 +56,7 @@ func GetPrometheusMetrics(t *testing.T, metricsEndpoint string) map[string]pcm.M
 	// This code is mostly copied from https://github.com/prometheus/prom2json except it
 	// returns MetricFamily objects as that is more useful than JSON for tests.
 	mfChan := make(chan *pcm.MetricFamily, 1024)
-	tlsConfig := &tls.Config{InsecureSkipVerify: true}
-	transport := &http.Transport{
-		TLSClientConfig: tlsConfig,
-	}
-
-	err := prom2json.FetchMetricFamilies(metricsEndpoint, mfChan, transport)
+	err := prom2json.FetchMetricFamilies(metricsEndpoint, mfChan, &http.Transport{})
 	require.NoError(t, err)
 	result := map[string]pcm.MetricFamily{}
 	for mf := range mfChan {


### PR DESCRIPTION
Signed-off-by: Kevin Earls <kearls@redhat.com>

This resolves issue #15 It is based on the [Prometheus Prom2JSON tool] (https://github.com/prometheus/prom2json) Prom2JSON was not a perfect fit as it is a CLI tool and returns JSON, so I copied a small amount of code from it but am otherwise using standard prometheus client APIs.