### PR TITLE
Download otelcol builder binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-OTELCOL_BUILDER_VERSION ?= 0.2.0
+OTELCOL_BUILDER_VERSION ?= 0.4.1
 GOFMT = gofmt
 GOLINT = golint
 LINT_LOG = .lint.log
@@ -33,14 +33,7 @@ build-collector: otelcol-builder
 
 .PHONY: otelcol-builder
 otelcol-builder:
-ifeq (, $(shell which opentelemetry-collector-builder))
-	@{ \
-	set -ex ;\
-	mkdir -p $(OTELCOL_BUILDER_DIR) ;\
-	curl -sLo $(OTELCOL_BUILDER) https://github.com/observatorium/opentelemetry-collector-builder/releases/download/v$(OTELCOL_BUILDER_VERSION)/opentelemetry-collector-builder_$(OTELCOL_BUILDER_VERSION)_$(GOOS)_$(GOARCH) ;\
-	chmod +x $(OTELCOL_BUILDER) ;\
-	}
-endif
+	@scripts/install_otelcol_builder.sh -d $(OTELCOL_BUILDER_DIR) -v $(OTELCOL_BUILDER_VERSION)
 
 .PHONY: e2e-tests
 e2e-tests: build e2e-tests-agent-smoke e2e-tests-collector-smoke

--- a/scripts/install_otelcol_builder.sh
+++ b/scripts/install_otelcol_builder.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+while getopts d:v: flag
+do
+    case "${flag}" in
+        d) otelcol_builder_dir=${OPTARG};;
+        v) otelcol_builder_version=${OPTARG};;
+    esac
+done
+
+if [ "$(which opentelemetry-collector-builder)" ]; then
+  echo "opentelemetry-collector-builder already installed"
+  exit 0
+fi
+
+echo "installing opentelemetry-collector-builder"
+otelcol_builder="$otelcol_builder_dir/opentelemetry-collector-builder"
+goos=$(go env GOOS)
+goarch=$(go env GOARCH)
+
+set -ex
+mkdir -p "$otelcol_builder_dir"
+curl -sLo "$otelcol_builder" "https://github.com/observatorium/opentelemetry-collector-builder/releases/download/v${otelcol_builder_version}/opentelemetry-collector-builder_${otelcol_builder_version}_${goos}_${goarch}"
+chmod +x "${otelcol_builder}"

--- a/tools.go
+++ b/tools.go
@@ -4,6 +4,5 @@ package jaeger_otelcol
 
 // https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
 import (
-	_ "github.com/observatorium/opentelemetry-collector-builder"
 	_ "golang.org/x/lint/golint"
 )


### PR DESCRIPTION
Signed-off-by: albertteoh <albert.teoh@logz.io>

Fixes #20 

Reverts the change made due to an outdated README instruction. The preferred way to install otel builder is to download the binary.

This PR also adds support for MacOS installations of otel builder.